### PR TITLE
Don't translate the Icon key in .desktop files

### DIFF
--- a/transifex/resources/formats/desktop.py
+++ b/transifex/resources/formats/desktop.py
@@ -100,7 +100,7 @@ class DesktopHandler(SimpleCompilerFactory, Handler):
     delimiter = '='
     # We are only intrested in localestrings, see
     # http://standards.freedesktop.org/desktop-entry-spec/latest/ar01s05.html
-    localized_keys = ['Name', 'GenericName', 'Comment', 'Icon', ]
+    localized_keys = ['Name', 'GenericName', 'Comment', ]
 
     def _is_comment_line(self, line):
         """Return True, if the line is a comment."""


### PR DESCRIPTION
In the .desktop file format, the `Icon` key is used to set an icon using a standard name or a path.

Here's what the spec says:


> Icon to display in file manager, menus, etc. If the name is an absolute path, the given file will be used. If the name is not an absolute path, the algorithm described in the Icon Theme Specification will be used to locate the icon. 

While it's technically a "localestring" it makes absolutely no sense to have it sent to translators, especially since there is no indication in the translation interface that this is an icon (a file name, not a phrase).

As a result, we get translations like this:

```ini
Icon=help-about
Icon[zh_TW]=關於幫助
Icon[zh_CN]=关于帮助
Icon[uk]=help-about
Icon[th_TH]=วิธีใช้-เกี่ยวกับ
Icon[ru_RU]=help-about
Icon[ru]=помощь-Oб
Icon[ro_RO]=help-about
Icon[pt_BR]=ajuda-sobre
Icon[pt]=help-about
Icon[pl_PL]=pomoc-o
Icon[it_IT]=help-about
Icon[eu]=laguntza-honi buruz
Icon[es_VE]=help-about
Icon[es]=ayuda-acerca
Icon[el_GR]=help-about
Icon[de_DE]=Hilfe-Über
Icon[da_DK]=hjælp-om
Icon[da]=help-about
Icon[cs_CZ]=Informace
Icon[cs]=Informace
```