### PR TITLE
remove "forgot password" from tabbed sequence

### DIFF
--- a/transifex/templates/userena/signin_form.html
+++ b/transifex/templates/userena/signin_form.html
@@ -11,7 +11,7 @@
 {{ block.super }}
 <script  type="text/javascript">
 $(document).ready(function(){
-	$('<a class="forgot-pass" href="{% url userena_password_reset %}">({% trans "Forgot your password?" %})</a>').appendTo('label[for="id_password"]');
+	$('<a class="forgot-pass" tabindex="-1" href="{% url userena_password_reset %}">({% trans "Forgot your password?" %})</a>').appendTo('label[for="id_password"]');
 });
 </script>
 {% endblock %}


### PR DESCRIPTION
remove "forgot password" from tabbed sequence, to improve keyboard experience for those who Tab though input fields.
