### PR TITLE
javascriptically fill in name and i18n_type fields for new resources

### DIFF
--- a/transifex/templates/resources/upload_create_resource_form.html
+++ b/transifex/templates/resources/upload_create_resource_form.html
@@ -4,10 +4,10 @@
 <script type="text/javascript">
 
 $(document).ready(function(){
-		$(".tipsy_enable").tipsy({'html':true, 'gravity':'s'});
-		$("span.required").each(function(){
-			$(this).parents('.tx-form-field').find('label').append($(this));
-			});
+    $(".tipsy_enable").tipsy({'html':true, 'gravity':'s'});
+    $("span.required").each(function(){
+        $(this).parents('.tx-form-field').find('label').append($(this));
+    });
     $("#create_new_resource").toggle(function(){
         $("#create_new_resource_form").slideDown(function(){$(".tx-form select").chosen();});
     }, function(){
@@ -19,9 +19,23 @@ $(document).ready(function(){
     {% endif %}
 
     $("#create-resource-submit").submit(function(){
-      $("div#notification-container div").html("{% trans "Uploading resource" %}");
-			$("div#notification-container").fadeIn("fast");
+        $("div#notification-container div").html("{% trans "Uploading resource" %}");
+        $("div#notification-container").fadeIn("fast");
     });
+
+    // auto-suggest name and type
+    $("#id_create_form-source_file").change(function(){
+        var filename = $(this).val();
+        $("#id_create_form-name").val(filename);
+        var ext = filename.split(".")[1].toLowerCase()
+        // simply pick first option that fits
+        $('#id_create_form-i18n_method option').each(function(){
+            if (this.text.indexOf("."+ext) != -1 )
+                this.selected = "selected"
+        });
+        // trigger Chosen update
+        $("#id_create_form-i18n_method").trigger("liszt:updated");
+    })
 });
 </script>
 


### PR DESCRIPTION
Resource name and i18n type should be filled in automatically, as for the most cases this is trivial, and asking a user to reenter them is just boring.
